### PR TITLE
update schema to fix bug

### DIFF
--- a/functions/models/promise.js
+++ b/functions/models/promise.js
@@ -14,8 +14,8 @@ const createSchema = joi.object().keys({
   contributor_id: joi.string().required(),
   politician_id: joi.string().required(),
   source_date: joi
-    .date()
-    .iso()
+    .string()
+    .isoDate()
     .required(),
   source_name: joi.string().required(),
   source_url: joi


### PR DESCRIPTION
- previous schema configuration somehow returned validateData with source_date as object rather than string
- updating schema from `.date().iso()` to `string().isoDate()` preserved the string format