### PR TITLE
fix(firebaseAuth-middleware): error 403 if expired token

### DIFF
--- a/functions/etc/middlewares.js
+++ b/functions/etc/middlewares.js
@@ -88,7 +88,7 @@ const firebaseAuth = function(req, res, next) {
       })
       .catch(error => {
         console.error(error);
-        res.status(400);
+        res.status(403);
         res.send('There has been an error in authorization.');
       });
   }


### PR DESCRIPTION
- previously it was 400 which does not indicate the problem
- this change allows clients to react accordingly