### PR TITLE
Add the "promise_ids" field on the List model

### DIFF
--- a/functions/schemas/list.ts
+++ b/functions/schemas/list.ts
@@ -2,12 +2,17 @@ import joi = require('joi');
 
 export interface IList {
   title: string;
+  promise_ids: Array<string>;
   created_at: string;
   updated_at: string;
 }
 
 export const create = joi.object().keys({
   title: joi.string().required(),
+  promise_ids: joi
+    .array()
+    .items(joi.string())
+    .default([]),
   created_at: joi
     .date()
     .iso()
@@ -20,6 +25,7 @@ export const create = joi.object().keys({
 
 export const update = joi.object().keys({
   title: joi.string(),
+  promise_ids: joi.array().items(joi.string()),
   updated_at: joi
     .date()
     .iso()

--- a/functions/test/schemas/list.test.ts
+++ b/functions/test/schemas/list.test.ts
@@ -72,7 +72,57 @@ describe('list schema', () => {
         .catch(done);
     });
 
-    it('creates a list with fields of valid type', async () => {
+    it('expects the "promise_ids" field to be an array', done => {
+      const attrs = {
+        title: 'weather',
+        promise_ids: 1234,
+        created_at: newYearsEve,
+        updated_at: malaysiaDay
+      };
+
+      createSchema
+        .validate(attrs)
+        .then(() => {
+          done(new Error('Expected a failing path to execute'));
+        })
+        .catch(err => {
+          expect(err).to.be.an.instanceOf(Error);
+          expect(err.name).to.equal('ValidationError');
+
+          const [{ message }] = err.details;
+          expect(message).to.equal('"promise_ids" must be an array');
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('expects the "promise_ids" field to be an array of strings', done => {
+      const attrs = {
+        title: 'weather',
+        promise_ids: ['a1', 2, 3, 4],
+        created_at: newYearsEve,
+        updated_at: malaysiaDay
+      };
+
+      createSchema
+        .validate(attrs)
+        .then(() => {
+          done(new Error('Expected a failing path to execute'));
+        })
+        .catch(err => {
+          expect(err).to.be.an.instanceOf(Error);
+          expect(err.name).to.equal('ValidationError');
+
+          const [{ message }] = err.details;
+          expect(message).to.equal('"1" must be a string');
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('does not require the "promise_ids" field', async () => {
       const attrs = {
         title: 'public safety',
         created_at: newYearsEve.toISOString(),
@@ -81,9 +131,58 @@ describe('list schema', () => {
 
       const result: any = await createSchema.validate(attrs);
 
-      expect(result).to.have.all.keys('title', 'created_at', 'updated_at');
+      expect(result).to.have.all.keys(
+        'title',
+        'promise_ids',
+        'created_at',
+        'updated_at'
+      );
+
+      expect(result.promise_ids).to.deep.equal([]);
+    });
+
+    it('creates a list with a default value for the "promise_ids" field', async () => {
+      const attrs = {
+        title: 'public safety',
+        promise_ids: ['abc1', 'abc2', 'abc3'],
+        created_at: newYearsEve.toISOString(),
+        updated_at: malaysiaDay.toISOString()
+      };
+
+      const result: any = await createSchema.validate(attrs);
+
+      expect(result).to.have.all.keys(
+        'title',
+        'promise_ids',
+        'created_at',
+        'updated_at'
+      );
 
       expect(result.title).to.be.a('string');
+      expect(result.promise_ids).to.be.an('array');
+      expect(result.created_at).to.be.an.instanceOf(Date);
+      expect(result.updated_at).to.be.an.instanceOf(Date);
+    });
+
+    it('creates a list with fields of valid type', async () => {
+      const attrs = {
+        title: 'public safety',
+        promise_ids: ['abc1', 'abc2', 'abc3'],
+        created_at: newYearsEve.toISOString(),
+        updated_at: malaysiaDay.toISOString()
+      };
+
+      const result: any = await createSchema.validate(attrs);
+
+      expect(result).to.have.all.keys(
+        'title',
+        'promise_ids',
+        'created_at',
+        'updated_at'
+      );
+
+      expect(result.title).to.be.a('string');
+      expect(result.promise_ids).to.be.an('array');
       expect(result.created_at).to.be.an.instanceOf(Date);
       expect(result.updated_at).to.be.an.instanceOf(Date);
     });
@@ -91,6 +190,7 @@ describe('list schema', () => {
     it('creates a list', async () => {
       const attrs = {
         title: 'public safety',
+        promise_ids: ['abc1', 'abc2', 'abc3'],
         created_at: newYearsEve.toISOString(),
         updated_at: malaysiaDay.toISOString()
       };
@@ -99,6 +199,7 @@ describe('list schema', () => {
 
       expect(result).to.deep.equal({
         title: attrs.title,
+        promise_ids: attrs.promise_ids,
         created_at: newYearsEve,
         updated_at: malaysiaDay
       });
@@ -112,7 +213,12 @@ describe('list schema', () => {
 
       const result: any = await createSchema.validate(attrs);
 
-      expect(result).to.have.all.keys('title', 'created_at', 'updated_at');
+      expect(result).to.have.all.keys(
+        'title',
+        'promise_ids',
+        'created_at',
+        'updated_at'
+      );
 
       expect(result.title).to.equal(attrs.title);
 
@@ -131,7 +237,12 @@ describe('list schema', () => {
 
       const result: any = await createSchema.validate(attrs);
 
-      expect(result).to.have.all.keys('title', 'created_at', 'updated_at');
+      expect(result).to.have.all.keys(
+        'title',
+        'promise_ids',
+        'created_at',
+        'updated_at'
+      );
 
       expect(result.title).to.equal(attrs.title);
 
@@ -215,7 +326,56 @@ describe('list schema', () => {
         .catch(done);
     });
 
-    it('returns list fields of valid type', async () => {
+    it('expects the "promise_ids" field to be an array', done => {
+      const attrs = {
+        title: 'weather',
+        promise_ids: 1234,
+        created_at: newYearsEve,
+        updated_at: malaysiaDay
+      };
+
+      updateSchema
+        .validate(attrs)
+        .then(() => {
+          done(new Error('Expected a failing path to execute'));
+        })
+        .catch(err => {
+          expect(err).to.be.an.instanceOf(Error);
+          expect(err.name).to.equal('ValidationError');
+
+          const [{ message }] = err.details;
+          expect(message).to.equal('"promise_ids" must be an array');
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('expects the "promise_ids" field to be an array of strings', done => {
+      const attrs = {
+        title: 'weather',
+        promise_ids: ['a1', 2, 3, 4],
+        updated_at: malaysiaDay
+      };
+
+      updateSchema
+        .validate(attrs)
+        .then(() => {
+          done(new Error('Expected a failing path to execute'));
+        })
+        .catch(err => {
+          expect(err).to.be.an.instanceOf(Error);
+          expect(err.name).to.equal('ValidationError');
+
+          const [{ message }] = err.details;
+          expect(message).to.equal('"1" must be a string');
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('does not overwrite the "promise_ids" field if not given', async () => {
       const attrs = {
         title: 'public safety',
         updated_at: malaysiaDay.toISOString()
@@ -224,20 +384,35 @@ describe('list schema', () => {
       const result: any = await updateSchema.validate(attrs);
 
       expect(result).to.have.all.keys('title', 'updated_at');
+    });
+
+    it('returns list fields of valid type', async () => {
+      const attrs = {
+        title: 'public safety',
+        promise_ids: ['2a', '5a'],
+        updated_at: malaysiaDay.toISOString()
+      };
+
+      const result: any = await updateSchema.validate(attrs);
+
+      expect(result).to.have.all.keys('title', 'promise_ids', 'updated_at');
       expect(result.title).to.be.a('string');
+      expect(result.promise_ids).to.be.an('array');
       expect(result.updated_at).to.be.instanceOf(Date);
     });
 
     it('updates a list given attributes', async () => {
       const attrs = {
         title: 'ecology',
+        promise_ids: ['2a', '5a'],
         updated_at: newYearsEve.toISOString()
       };
 
       const result: any = await updateSchema.validate(attrs);
 
-      expect(result).to.have.all.keys('title', 'updated_at');
+      expect(result).to.have.all.keys('title', 'promise_ids', 'updated_at');
       expect(result.title).to.equal(attrs.title);
+      expect(result.promise_ids).to.deep.equal(attrs.promise_ids);
 
       const updatedAtDiff = newYearsEve.getTime() - result.updated_at.getTime();
 


### PR DESCRIPTION
Issue ref. [LFRB9IeI/387-api-list-feature](https://trello.com/c/LFRB9IeI/387-api-list-feature)

This PR implements the `promise_ids` field on the List model.

P.S. I kind of looked at my tests and realized they are rather messy. Would you mind if I refactor them some time after the issue is done?
P.P.S. What do you think about introducing a factory library to build fake data for models in tests automatically?
