### PR TITLE
chore: set NODE_ENV to 'test' when running tests

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "precommit": "pretty-quick --staged",
     "build": "tsc",
     "test":
-      "./node_modules/mocha/bin/mocha -r ts-node/register test/**/*.test.ts"
+      "NODE_ENV=test ./node_modules/mocha/bin/mocha -r ts-node/register test/**/*.test.ts"
   },
   "dependencies": {
     "body-parser": "^1.18.3",

--- a/functions/test/env.test.ts
+++ b/functions/test/env.test.ts
@@ -1,0 +1,12 @@
+import 'mocha';
+import { expect } from 'chai';
+
+describe('test env variable', () => {
+  it('is defined for the current environment', () => {
+    expect(process.env.NODE_ENV).to.not.be.undefined;
+  });
+
+  it('is set to "test"', () => {
+    expect(process.env.NODE_ENV).to.equal('test');
+  });
+});

--- a/functions/test/sample.test.ts
+++ b/functions/test/sample.test.ts
@@ -1,9 +1,0 @@
-import 'mocha';
-import { expect } from 'chai';
-
-describe('calculate', function() {
-  it('add', function() {
-    const result = 5 + 2;
-    expect(result).to.equal(7);
-  });
-});


### PR DESCRIPTION
Issue ref. [LFRB9IeI/387-api-list-feature](https://trello.com/c/LFRB9IeI/387-api-list-feature)

As I was working on the issue I came to the realization we are not setting the `NODE_ENV` variable, which may come in handy for testing (e.g. exporting server instances for further testing).

This PR attempts to address that.
