### PR TITLE
chore: install the mock-cloud-firestore package

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4029,6 +4029,14 @@
         }
       }
     },
+    "mock-cloud-firestore": {
+      "version": "0.9.2",
+      "resolved":
+        "https://registry.npmjs.org/mock-cloud-firestore/-/mock-cloud-firestore-0.9.2.tgz",
+      "integrity":
+        "sha512-67oIz480ndjQlq8QfAdeUra0/EIiPmEjilrUkJQE1gLTEYrID5HuWcJch8ZcmpgrSCZm5G39yxVExfavjTIh4Q==",
+      "dev": true
+    },
     "modelo": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/modelo/-/modelo-4.2.3.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -33,6 +33,7 @@
     "chai": "^4.2.0",
     "husky": "^0.14.3",
     "mocha": "^6.0.2",
+    "mock-cloud-firestore": "0.9.2",
     "prettier": "1.11.1",
     "pretty-quick": "^1.6.0",
     "ts-node": "^8.0.3",

--- a/functions/test/models/list/types.d.ts
+++ b/functions/test/models/list/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'mock-cloud-firestore';


### PR DESCRIPTION
Issue ref. [LFRB9IeI/387-api-list-feature](https://trello.com/c/LFRB9IeI/387-api-list-feature)

This PR installs the `mock-cloud-firestore` package which is useful for mocking the Firebase/Firestore in tests.

For documentation, please see the package's page on npm:
https://www.npmjs.com/package/mock-cloud-firestore
