### PR TITLE
fix(models/promise/update): skip updateListIds when no change

### DIFF
--- a/functions/models/promise/update.ts
+++ b/functions/models/promise/update.ts
@@ -17,8 +17,9 @@ const update = db => async (id: string, data: IPromise) => {
   const previouslyHas = !previouslyNone;
   const updateHas = data.list_ids && data.list_ids.length > 0;
   const updateNone = !updateHas;
+  const updateDoesNotInvolveListIds = !data.list_ids;
 
-  if (previouslyNone && updateNone) {
+  if ((previouslyNone && updateNone) || updateDoesNotInvolveListIds) {
     return await db
       .collection('promises')
       .doc(id)


### PR DESCRIPTION
client would error when the promise#update operation included no `list_ids` (when the promise does have `list_ids`)

This happened when promiseUpdate#create triggered promise#update