### PR TITLE
feat: allow the optional "description" field in list schema

### DIFF
--- a/functions/schemas/list.ts
+++ b/functions/schemas/list.ts
@@ -7,6 +7,7 @@ export interface IList {
   promise_ids: string[];
   created_at: string;
   updated_at: string;
+  description?: string;
 }
 
 export const create = joi.object().keys({
@@ -24,7 +25,8 @@ export const create = joi.object().keys({
   updated_at: joi
     .date()
     .iso()
-    .default(() => new Date(), 'the time of update')
+    .default(() => new Date(), 'the time of update'),
+  description: joi.string().optional()
 });
 
 export const update = joi.object().keys({

--- a/functions/schemas/list.ts
+++ b/functions/schemas/list.ts
@@ -37,5 +37,6 @@ export const update = joi.object().keys({
   updated_at: joi
     .date()
     .iso()
-    .default(() => new Date(), 'the time of update')
+    .default(() => new Date(), 'the time of update'),
+  description: joi.string().optional()
 });

--- a/functions/test/schemas/list.test.ts
+++ b/functions/test/schemas/list.test.ts
@@ -463,6 +463,14 @@ describe('list schema', () => {
         })
         .catch(done);
     });
+
+    it('accepts the "description" field', async () => {
+      const attrs = { title: 'public safety', description: 'description' };
+      const result: any = await updateSchema.validate(attrs);
+
+      expect(result.description).to.be.a('string');
+      expect(result.description).to.equal(attrs.description);
+    });
   });
 
   const malaysiaDay = (() => {

--- a/functions/test/schemas/list.test.ts
+++ b/functions/test/schemas/list.test.ts
@@ -275,6 +275,14 @@ describe('list schema', () => {
         })
         .catch(done);
     });
+
+    it('accepts the "description" field', async () => {
+      const attrs = { title: 'public safety', description: 'description' };
+      const result: any = await createSchema.validate(attrs);
+
+      expect(result.description).to.be.a('string');
+      expect(result.description).to.equal(attrs.description);
+    });
   });
 
   describe('update', () => {


### PR DESCRIPTION
Issue ref. [sE3z1U74](https://trello.com/c/sE3z1U74/399-all-add-description-to-list)
