### PR TITLE
feat: implement lead schema

### DIFF
--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -1,12 +1,56 @@
 import joi from 'joi';
+import utils from '../etc/utils';
 
-export const create = joi.object().keys({
-  link: joi.string().required(),
-  review_status: joi.string().required(),
-  type: joi.string().required(),
-  submitter: joi.string().required(),
-  reviewed_by: joi.string().required(),
-  notes: joi.string().required(),
+interface ILead {
+  assigned_tracker: string;
+  created_at: string;
+  link: string;
+  notes: string;
+  original_promise: string;
+  reviewed_by: string;
+  review_status: string;
+  submitter: string;
+  type: string;
+  updated_at: string;
+}
+
+const create = joi.object().keys({
   assigned_tracker: joi.string().required(),
-  original_promise: joi.string().required()
+  created_at: joi
+    .date()
+    .iso()
+    .default(utils.now, 'Time of creation'),
+  link: joi.string().required(),
+  notes: joi.string().required(),
+  original_promise: joi.string().required(),
+  reviewed_by: joi.string().required(),
+  review_status: joi.string().required(),
+  submitter: joi.string().required(),
+  type: joi.string().required(),
+  updated_at: joi
+    .date()
+    .iso()
+    .default(utils.now, 'Time of update')
 });
+
+const update = joi.object().keys({
+  assigned_tracker: joi.string().required(),
+  created_at: joi
+    .date()
+    .iso()
+    .default(utils.now, 'Time of creation'),
+  link: joi.string().required(),
+  notes: joi.string().required(),
+  original_promise: joi.string().required(),
+  reviewed_by: joi.string().required(),
+  review_status: joi.string().required(),
+  submitter: joi.string().required(),
+  type: joi.string().required(),
+  updated_at: joi
+    .date()
+    .iso()
+    .default(utils.now, 'Time of update')
+});
+
+export const create;
+export const update;

--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -1,7 +1,7 @@
 import joi from 'joi';
 import utils from '../etc/utils';
 
-interface ILead {
+export interface ILead {
   assigned_tracker: string;
   created_at: string;
   link: string;
@@ -14,7 +14,7 @@ interface ILead {
   updated_at: string;
 }
 
-const create = joi.object().keys({
+export const create = joi.object().keys({
   assigned_tracker: joi.string().required(),
   created_at: joi
     .date()
@@ -33,7 +33,7 @@ const create = joi.object().keys({
     .default(utils.now, 'Time of update')
 });
 
-const update = joi.object().keys({
+export const update = joi.object().keys({
   assigned_tracker: joi.string().required(),
   created_at: joi
     .date()
@@ -51,6 +51,3 @@ const update = joi.object().keys({
     .iso()
     .default(utils.now, 'Time of update')
 });
-
-export const create;
-export const update;

--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -4,6 +4,7 @@ import utils from '../etc/utils';
 export interface ILead {
   assigned_tracker: string;
   created_at: string;
+  id: string;
   link: string;
   notes: string;
   original_promise: string;

--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -40,6 +40,7 @@ export const update = joi.object().keys({
     .date()
     .iso()
     .default(utils.now, 'Time of creation'),
+  id: joi.string().required(),
   link: joi.string().required(),
   notes: joi.string().required(),
   original_promise: joi.string().required(),

--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -27,7 +27,10 @@ export const create = joi.object().keys({
   reviewed_by: joi.string().required(),
   review_status: joi.string().required(),
   submitter: joi.string().required(),
-  type: joi.string().required(),
+  type: joi
+    .string()
+    .valid('promise', 'promiseUpdate')
+    .required(),
   updated_at: joi
     .date()
     .iso()
@@ -47,7 +50,10 @@ export const update = joi.object().keys({
   reviewed_by: joi.string().required(),
   review_status: joi.string().required(),
   submitter: joi.string().required(),
-  type: joi.string().required(),
+  type: joi
+    .string()
+    .valid('promise', 'promiseUpdate')
+    .required(),
   updated_at: joi
     .date()
     .iso()

--- a/functions/schemas/lead.ts
+++ b/functions/schemas/lead.ts
@@ -1,0 +1,12 @@
+import joi from 'joi';
+
+export const create = joi.object().keys({
+  link: joi.string().required(),
+  review_status: joi.string().required(),
+  type: joi.string().required(),
+  submitter: joi.string().required(),
+  reviewed_by: joi.string().required(),
+  notes: joi.string().required(),
+  assigned_tracker: joi.string().required(),
+  original_promise: joi.string().required()
+});

--- a/functions/schemas/promiseLead.ts
+++ b/functions/schemas/promiseLead.ts
@@ -1,8 +1,0 @@
-export interface IPromiseLead {
-  contains_promise: boolean;
-  contributor_email?: string;
-  notes?: string;
-  processed: boolean;
-  source_url: string;
-  tracker_id?: string;
-}

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -8,7 +8,6 @@ import {
 describe.only('lead schema', () => {
   describe('create', () => {
     const validAttrs: any = {
-      // TODO: move me to a factory
       assigned_tracker: 'b5hqf73',
       created_at: '2019-05-20T13:14:41.489Z',
       link: 'https://example.org/foo/bar/quix',
@@ -312,7 +311,6 @@ describe.only('lead schema', () => {
 
   describe('update', () => {
     const validAttrs: any = {
-      // TODO: move me to a factory
       assigned_tracker: 'b5hqf73',
       created_at: '2019-05-20T13:14:41.489Z',
       id: 'gam3s42f3f2',

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -2,26 +2,25 @@ import 'mocha';
 import { expect } from 'chai';
 import {
   create as createSchema,
-  update as updateSchema,
-  ILead
+  update as updateSchema
 } from '../../schemas/lead';
 
 describe.only('lead schema', () => {
-  const validAttrs: any = {
-    // TODO: move me to a factory
-    assigned_tracker: 'b5hqf73',
-    created_at: '2019-05-20T13:14:41.489Z',
-    link: 'https://example.org/foo/bar/quix',
-    notes: 'Lorem Ipsum Dignitatum.',
-    original_promise: 'fg4867',
-    reviewed_by: 'g4342f',
-    review_status: 'pending',
-    submitter: 'f43g423',
-    type: 'promise',
-    updated_at: '2019-05-20T13:14:41.489Z'
-  };
-
   describe('create', () => {
+    const validAttrs: any = {
+      // TODO: move me to a factory
+      assigned_tracker: 'b5hqf73',
+      created_at: '2019-05-20T13:14:41.489Z',
+      link: 'https://example.org/foo/bar/quix',
+      notes: 'Lorem Ipsum Dignitatum.',
+      original_promise: 'fg4867',
+      reviewed_by: 'g4342f',
+      review_status: 'pending',
+      submitter: 'f43g423',
+      type: 'promise',
+      updated_at: '2019-05-20T13:14:41.489Z'
+    };
+
     describe('"link" field', () => {
       it('expects the "link" to be present', async () => {
         const attrs: any = { ...validAttrs };
@@ -312,6 +311,21 @@ describe.only('lead schema', () => {
   });
 
   describe('update', () => {
+    const validAttrs: any = {
+      // TODO: move me to a factory
+      assigned_tracker: 'b5hqf73',
+      created_at: '2019-05-20T13:14:41.489Z',
+      id: 'gam3s42f3f2',
+      link: 'https://example.org/foo/bar/quix',
+      notes: 'Lorem Ipsum Dignitatum.',
+      original_promise: 'fg4867',
+      reviewed_by: 'g4342f',
+      review_status: 'pending',
+      submitter: 'f43g423',
+      type: 'promise',
+      updated_at: '2019-05-20T13:14:41.489Z'
+    };
+
     describe('"link" field', () => {
       it('expects the "link" to be present', async () => {
         const attrs: any = { ...validAttrs };
@@ -335,6 +349,36 @@ describe.only('lead schema', () => {
           await updateSchema.validate(attrs);
         } catch (err) {
           expectValidationError(err).withMessage('"link" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"id" field', () => {
+      it('expects the "id" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.id;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"id" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "id" to be a string', async () => {
+        const attrs: any = { ...validAttrs, id: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"id" must be a string');
           return;
         }
 

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -78,6 +78,21 @@ describe.only('lead schema', () => {
 
         throw new Error('Expected validation to fail.');
       });
+
+      it('expects the "type" to be a supported value', async () => {
+        const attrs: any = { ...validAttrs, type: 'foo' };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"type" must be one of [promise, promiseUpdate]'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
     });
 
     describe('"submitter" field', () => {
@@ -407,6 +422,21 @@ describe.only('lead schema', () => {
           await updateSchema.validate(attrs);
         } catch (err) {
           expectValidationError(err).withMessage('"type" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "type" to be a supported value', async () => {
+        const attrs: any = { ...validAttrs, type: 'foo' };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"type" must be one of [promise, promiseUpdate]'
+          );
           return;
         }
 

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -7,21 +7,21 @@ import {
 } from '../../schemas/lead';
 
 describe.only('lead schema', () => {
-  describe('create', () => {
-    const validAttrs: ILead = {
-      // TODO: move me to a factory
-      assigned_tracker: 'b5hqf73',
-      created_at: '2019-05-20T13:14:41.489Z',
-      link: 'https://example.org/foo/bar/quix',
-      notes: 'Lorem Ipsum Dignitatum.',
-      original_promise: 'fg4867',
-      reviewed_by: 'g4342f',
-      review_status: 'pending',
-      submitter: 'f43g423',
-      type: 'promise',
-      updated_at: '2019-05-20T13:14:41.489Z'
-    };
+  const validAttrs: ILead = {
+    // TODO: move me to a factory
+    assigned_tracker: 'b5hqf73',
+    created_at: '2019-05-20T13:14:41.489Z',
+    link: 'https://example.org/foo/bar/quix',
+    notes: 'Lorem Ipsum Dignitatum.',
+    original_promise: 'fg4867',
+    reviewed_by: 'g4342f',
+    review_status: 'pending',
+    submitter: 'f43g423',
+    type: 'promise',
+    updated_at: '2019-05-20T13:14:41.489Z'
+  };
 
+  describe('create', () => {
     describe('"link" field', () => {
       it('expects the "link" to be present', async () => {
         const attrs: any = { ...validAttrs };
@@ -299,6 +299,296 @@ describe.only('lead schema', () => {
 
         try {
           await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"updated_at" must be a valid ISO 8601 date'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+  });
+
+  describe('update', () => {
+    describe('"link" field', () => {
+      it('expects the "link" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.link;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"link" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "link" to be a string', async () => {
+        const attrs: any = { ...validAttrs, link: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"link" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"type" field', () => {
+      it('expects the "type" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.type;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"type" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "type" to be a string', async () => {
+        const attrs: any = { ...validAttrs, type: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"type" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"submitter" field', () => {
+      it('expects the "submitter" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.submitter;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"submitter" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "submitter" to be a string', async () => {
+        const attrs: any = { ...validAttrs, submitter: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"submitter" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"review_status" field', () => {
+      it('expects the "review_status" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.review_status;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"review_status" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "review_status" to be a string', async () => {
+        const attrs: any = { ...validAttrs, review_status: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"review_status" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"reviewed_by" field', () => {
+      it('expects the "reviewed_by" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.reviewed_by;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"reviewed_by" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "reviewed_by" to be a string', async () => {
+        const attrs: any = { ...validAttrs, reviewed_by: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"reviewed_by" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"original_promise" field', () => {
+      it('expects the "original_promise" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.original_promise;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"original_promise" is required'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "original_promise" to be a string', async () => {
+        const attrs: any = { ...validAttrs, original_promise: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"original_promise" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"notes" field', () => {
+      it('expects the "notes" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.notes;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"notes" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "notes" to be a string', async () => {
+        const attrs: any = { ...validAttrs, notes: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"notes" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"assigned_tracker" field', () => {
+      it('expects the "assigned_tracker" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.assigned_tracker;
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"assigned_tracker" is required'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "assigned_tracker" to be a string', async () => {
+        const attrs: any = { ...validAttrs, assigned_tracker: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"assigned_tracker" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"created_at" field', () => {
+      it('expects the "created_at" to be a string', async () => {
+        const attrs: any = { ...validAttrs, created_at: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"created_at" must be a valid ISO 8601 date'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"updated_at" field', () => {
+      it('expects the "updated_at" to be a string', async () => {
+        const attrs: any = { ...validAttrs, updated_at: 52765 };
+
+        try {
+          await updateSchema.validate(attrs);
         } catch (err) {
           expectValidationError(err).withMessage(
             '"updated_at" must be a valid ISO 8601 date'

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../schemas/lead';
 
 describe.only('lead schema', () => {
-  const validAttrs: ILead = {
+  const validAttrs: any = {
     // TODO: move me to a factory
     assigned_tracker: 'b5hqf73',
     created_at: '2019-05-20T13:14:41.489Z',

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -5,7 +5,7 @@ import {
   update as updateSchema
 } from '../../schemas/lead';
 
-describe.only('lead schema', () => {
+describe('lead schema', () => {
   describe('create', () => {
     const validAttrs: any = {
       assigned_tracker: 'b5hqf73',

--- a/functions/test/schemas/lead.test.ts
+++ b/functions/test/schemas/lead.test.ts
@@ -1,0 +1,325 @@
+import 'mocha';
+import { expect } from 'chai';
+import {
+  create as createSchema,
+  update as updateSchema,
+  ILead
+} from '../../schemas/lead';
+
+describe.only('lead schema', () => {
+  describe('create', () => {
+    const validAttrs: ILead = {
+      // TODO: move me to a factory
+      assigned_tracker: 'b5hqf73',
+      created_at: '2019-05-20T13:14:41.489Z',
+      link: 'https://example.org/foo/bar/quix',
+      notes: 'Lorem Ipsum Dignitatum.',
+      original_promise: 'fg4867',
+      reviewed_by: 'g4342f',
+      review_status: 'pending',
+      submitter: 'f43g423',
+      type: 'promise',
+      updated_at: '2019-05-20T13:14:41.489Z'
+    };
+
+    describe('"link" field', () => {
+      it('expects the "link" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.link;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"link" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "link" to be a string', async () => {
+        const attrs: any = { ...validAttrs, link: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"link" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"type" field', () => {
+      it('expects the "type" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.type;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"type" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "type" to be a string', async () => {
+        const attrs: any = { ...validAttrs, type: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"type" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"submitter" field', () => {
+      it('expects the "submitter" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.submitter;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"submitter" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "submitter" to be a string', async () => {
+        const attrs: any = { ...validAttrs, submitter: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"submitter" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"review_status" field', () => {
+      it('expects the "review_status" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.review_status;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"review_status" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "review_status" to be a string', async () => {
+        const attrs: any = { ...validAttrs, review_status: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"review_status" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"reviewed_by" field', () => {
+      it('expects the "reviewed_by" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.reviewed_by;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"reviewed_by" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "reviewed_by" to be a string', async () => {
+        const attrs: any = { ...validAttrs, reviewed_by: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"reviewed_by" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"original_promise" field', () => {
+      it('expects the "original_promise" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.original_promise;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"original_promise" is required'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "original_promise" to be a string', async () => {
+        const attrs: any = { ...validAttrs, original_promise: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"original_promise" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"notes" field', () => {
+      it('expects the "notes" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.notes;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"notes" is required');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "notes" to be a string', async () => {
+        const attrs: any = { ...validAttrs, notes: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage('"notes" must be a string');
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"assigned_tracker" field', () => {
+      it('expects the "assigned_tracker" to be present', async () => {
+        const attrs: any = { ...validAttrs };
+
+        delete attrs.assigned_tracker;
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"assigned_tracker" is required'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+
+      it('expects the "assigned_tracker" to be a string', async () => {
+        const attrs: any = { ...validAttrs, assigned_tracker: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"assigned_tracker" must be a string'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"created_at" field', () => {
+      it('expects the "created_at" to be a string', async () => {
+        const attrs: any = { ...validAttrs, created_at: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"created_at" must be a valid ISO 8601 date'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+
+    describe('"updated_at" field', () => {
+      it('expects the "updated_at" to be a string', async () => {
+        const attrs: any = { ...validAttrs, updated_at: 52765 };
+
+        try {
+          await createSchema.validate(attrs);
+        } catch (err) {
+          expectValidationError(err).withMessage(
+            '"updated_at" must be a valid ISO 8601 date'
+          );
+          return;
+        }
+
+        throw new Error('Expected validation to fail.');
+      });
+    });
+  });
+
+  function expectValidationError(actual: any) {
+    expect(actual).to.be.an.instanceOf(Error);
+    expect(actual.name).to.equal('ValidationError');
+
+    return {
+      withMessage(expectedMsg: string) {
+        const [{ message }] = actual.details;
+        expect(message).to.equal(expectedMsg);
+      }
+    };
+  }
+});


### PR DESCRIPTION
Ref. FN2s10GL

This PR creates the `create`, `update` schemas for leads, as well as the `ILead` interface.
