### PR TITLE
fix: comment out 'settings()' line

### DIFF
--- a/functions/models/list/list.ts
+++ b/functions/models/list/list.ts
@@ -9,7 +9,7 @@ async function list(
   dbOverride?: admin.firestore.Firestore
 ): Promise<object[]> {
   const db = dbOverride || admin.firestore();
-  db.settings({ timestampsInSnapshots: true });
+  // db.settings({ timestampsInSnapshots: true });
   const ref = await filter(db.collection('lists'), params, db);
   const snapshot = await ref.get();
 


### PR DESCRIPTION
```
 Firestore has already been started and its settings can no longer be changed. You can only call settings() before calling any other methods on a Firestore object.
    at Firestore.settings (/user_code/node_modules/firebase-admin/node_modules/@google-cloud/firestore/build/src/index.js:276:19)
    at Object.<anonymous> (/user_code/models/list/list.js:19:12)
```