### PR TITLE
fix(models/list/get): comment out `.settings()`

### DIFF
--- a/functions/models/list/get.ts
+++ b/functions/models/list/get.ts
@@ -7,7 +7,7 @@ async function get(
   dbOverride?: admin.firestore.Firestore
 ): Promise<admin.firestore.DocumentData | undefined> {
   const db = dbOverride || admin.firestore();
-  db.settings({ timestampsInSnapshots: true });
+  // db.settings({ timestampsInSnapshots: true });
   const snapshot = await db
     .collection('lists')
     .doc(id)


### PR DESCRIPTION
```
Error: Firestore has already been started and its settings can no longer be changed. You can only call settings() before calling any other methods on a Firestore object.
    at Firestore.settings (/user_code/node_modules/firebase-admin/node_modules/@google-cloud/firestore/build/src/index.js:276:19)
    at Object.<anonymous> (/user_code/models/list/get.js:18:12)
```