### PR TITLE
simplify serve script

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -8,9 +8,7 @@
     "lint": "tslint -c ./tslint.json './*/*.ts' './*.ts' -e './node_modules'",
     "lint:fix":
       "tslint --fix -c ./tslint.json './*/*.ts' './*.ts' -e './node_modules'",
-    "serve": "(tsc || true) && firebase serve --only functions",
-    "serve-h": "(tsc || true) && firebase serve --only functions,hosting",
-    "shell": "(tsc || true) && firebase experimental:functions:shell",
+    "serve": "(tsc || true) && firebase serve",
     "start": "(tsc || true) && npm run shell",
     "deploy": "(tsc || true) && firebase deploy --only functions",
     "logs": "(tsc || true) && firebase functions:log",


### PR DESCRIPTION
based on firebase doc `firebase serve` is equivalent to `firebase serve --only functions, hosting` 

also, `shell` script is not required. we can remove this.